### PR TITLE
missing include <string.h>

### DIFF
--- a/src/game/vmap/WorldModel.cpp
+++ b/src/game/vmap/WorldModel.cpp
@@ -19,6 +19,7 @@
 #include "WorldModel.h"
 #include "VMapDefinitions.h"
 #include "MapTree.h"
+#include <string.h>
 
 using G3D::Vector3;
 using G3D::Ray;


### PR DESCRIPTION
can't compile 'vmap_assembler' without this include under Debian Jessie